### PR TITLE
Storing httpbody data into input stream, in case stream data is nil.

### DIFF
--- a/netfox/Core/NFXHelper.swift
+++ b/netfox/Core/NFXHelper.swift
@@ -168,10 +168,18 @@ extension URLRequest
         }
     }
     
-    func getNFXBody() -> Data
+     func getNFXBody() -> Data
     {
+        if httpBodyStream == nil {
+            guard httpBody != nil else {
+                return httpBodyStream?.readfully() ?? URLProtocol.property(forKey: "NFXBodyData", in: self) as? Data ?? Data()
+            }
+            let inputStream = InputStream(data: httpBody!)
+            return inputStream.readfully()
+        }
         return httpBodyStream?.readfully() ?? URLProtocol.property(forKey: "NFXBodyData", in: self) as? Data ?? Data()
     }
+   
     
     func getCurl() -> String {
         guard let url = url else { return "" }


### PR DESCRIPTION
Storing httpbody data into input stream, in case stream data is nil. Useful in our case where we involve old NSURLConnection objects for making POST/PUT